### PR TITLE
feat: add animated mobile menu

### DIFF
--- a/akcii.html
+++ b/akcii.html
@@ -41,7 +41,14 @@
         <!-- Навигационное меню -->
         <nav class="navbar-fullwidth">
             <div class="container">
-                <!-- Мобильная кнопка убрана, меню всегда отображается -->
+                <button class="mobile-menu-toggle">
+                    <span class="menu-text">Меню</span>
+                    <span class="menu-icon">
+                        <span class="icon-bar"></span>
+                        <span class="icon-bar"></span>
+                        <span class="icon-bar"></span>
+                    </span>
+                </button>
 
                 <ul class="navbar-menu">
                     <li><a href="ceny.html">Цены</a></li>

--- a/ceny.html
+++ b/ceny.html
@@ -35,7 +35,14 @@
         </div>
         <nav class="navbar-fullwidth">
             <div class="container">
-                <!-- Мобильная кнопка убрана, меню всегда отображается -->
+                <button class="mobile-menu-toggle">
+                    <span class="menu-text">Меню</span>
+                    <span class="menu-icon">
+                        <span class="icon-bar"></span>
+                        <span class="icon-bar"></span>
+                        <span class="icon-bar"></span>
+                    </span>
+                </button>
                 <ul class="navbar-menu">
                     <li><a href="ceny.html">Цены</a></li>
                     <li><a href="potolki.html">Каталог</a></li>

--- a/company.html
+++ b/company.html
@@ -42,7 +42,14 @@
         <!-- Навигационное меню -->
         <nav class="navbar-fullwidth">
             <div class="container">
-                <!-- Мобильная кнопка убрана, меню всегда отображается -->
+                <button class="mobile-menu-toggle">
+                    <span class="menu-text">Меню</span>
+                    <span class="menu-icon">
+                        <span class="icon-bar"></span>
+                        <span class="icon-bar"></span>
+                        <span class="icon-bar"></span>
+                    </span>
+                </button>
 
                 <ul class="navbar-menu">
                     <li><a href="ceny.html">Цены</a></li>

--- a/css/style.css
+++ b/css/style.css
@@ -1304,16 +1304,8 @@ body {
 /* Дополнительные стили для улучшений                                */
 /* ------------------------------------------------------------------ */
 
-/* Всегда отображаем горизонтальное меню и скрываем мобильную кнопку */
-.mobile-menu-toggle {
-    display: none !important;
-}
-
-/* Навигационное меню всегда в одну строку */
-.navbar-menu {
-    display: flex !important;
-    flex-direction: row !important;
-}
+/* Ранее здесь скрывалась мобильная кнопка и принудительно показывалось меню.
+   Эти стили удалены, чтобы позволить адаптивное мобильное меню. */
 
 /* Уточняем размер Instagram-кнопки в отзывах */
 .instagram-link {
@@ -1413,35 +1405,38 @@ body {
 }
 
 /* ----------------------------------------------------------
- * Custom overrides for responsive navigation
- *
- * The original design hid the navigation menu on narrow screens and
- * relied on a hamburger icon.  For this project the client wants
- * the menu links to be always visible, even on mobile devices.  The
- * following media query overrides the earlier rules by forcing the
- * menu to display as a flexible row that wraps when necessary.  It
- * also hides the mobile menu toggle completely.
- */
+ * Адаптивное мобильное меню с анимацией выезда
+ * ---------------------------------------------------------- */
 @media (max-width: 992px) {
-    /* Hide the burger button entirely */
     .mobile-menu-toggle {
-        display: none !important;
-    }
-    /* Display the menu items in a flex container that wraps */
-    .navbar-menu {
         display: flex !important;
-        flex-direction: row;
-        flex-wrap: wrap;
+        justify-content: space-between;
+        align-items: center;
+    }
+    .navbar-menu {
+        position: absolute;
+        top: 100%;
+        left: 0;
         width: 100%;
+        background: #4C4C4CE5;
+        flex-direction: column;
+        max-height: 0;
+        overflow: hidden;
+        transition: max-height 0.3s ease;
     }
-    /* Each menu item takes half of the row on very small screens */
-    .navbar-menu li {
-        flex: 1 1 50%;
-        text-align: center;
+    .navbar-menu.show {
+        max-height: 500px;
     }
-    /* Reduce padding and font-size for small screens */
-    .navbar-menu a {
-        padding: 12px 8px;
-        font-size: 15px;
+    .mobile-menu-toggle .icon-bar {
+        transition: transform 0.3s ease, opacity 0.3s ease;
+    }
+    .mobile-menu-toggle.open .icon-bar:nth-child(1) {
+        transform: translateY(6px) rotate(45deg);
+    }
+    .mobile-menu-toggle.open .icon-bar:nth-child(2) {
+        opacity: 0;
+    }
+    .mobile-menu-toggle.open .icon-bar:nth-child(3) {
+        transform: translateY(-6px) rotate(-45deg);
     }
 }

--- a/index.html
+++ b/index.html
@@ -43,7 +43,14 @@
         <!-- Навигационное меню -->
         <nav class="navbar-fullwidth">
             <div class="container">
-                <!-- Мобильная кнопка убрана, меню всегда отображается -->
+                <button class="mobile-menu-toggle">
+                    <span class="menu-text">Меню</span>
+                    <span class="menu-icon">
+                        <span class="icon-bar"></span>
+                        <span class="icon-bar"></span>
+                        <span class="icon-bar"></span>
+                    </span>
+                </button>
 
                 <ul class="navbar-menu">
                     <li><a href="ceny.html">Цены</a></li>

--- a/js/components.js
+++ b/js/components.js
@@ -2,11 +2,19 @@
 function initCommonComponents() {
     // Инициализация мобильного меню
     const menuToggle = document.querySelector('.mobile-menu-toggle');
-    if (menuToggle) {
+    const menu = document.querySelector('.navbar-menu');
+    if (menuToggle && menu) {
         menuToggle.addEventListener('click', function() {
-            const menu = document.querySelector('.navbar-menu');
             menu.classList.toggle('show');
             this.classList.toggle('open');
+        });
+
+        // Закрываем меню при выборе пункта
+        menu.querySelectorAll('a').forEach(link => {
+            link.addEventListener('click', () => {
+                menu.classList.remove('show');
+                menuToggle.classList.remove('open');
+            });
         });
     }
 

--- a/kontakty.html
+++ b/kontakty.html
@@ -35,7 +35,14 @@
         </div>
         <nav class="navbar-fullwidth">
             <div class="container">
-                <!-- Мобильная кнопка убрана, меню всегда отображается -->
+                <button class="mobile-menu-toggle">
+                    <span class="menu-text">Меню</span>
+                    <span class="menu-icon">
+                        <span class="icon-bar"></span>
+                        <span class="icon-bar"></span>
+                        <span class="icon-bar"></span>
+                    </span>
+                </button>
                 <ul class="navbar-menu">
                     <li><a href="ceny.html">Цены</a></li>
                     <li><a href="potolki.html">Каталог</a></li>

--- a/otzyvy.html
+++ b/otzyvy.html
@@ -42,7 +42,14 @@
         <!-- Навигационное меню -->
         <nav class="navbar-fullwidth">
             <div class="container">
-                <!-- Мобильная кнопка убрана, меню всегда отображается -->
+                <button class="mobile-menu-toggle">
+                    <span class="menu-text">Меню</span>
+                    <span class="menu-icon">
+                        <span class="icon-bar"></span>
+                        <span class="icon-bar"></span>
+                        <span class="icon-bar"></span>
+                    </span>
+                </button>
 
                 <ul class="navbar-menu">
                     <li><a href="ceny.html">Цены</a></li>

--- a/potolki.html
+++ b/potolki.html
@@ -35,7 +35,14 @@
         </div>
         <nav class="navbar-fullwidth">
             <div class="container">
-                <!-- Мобильная кнопка убрана, меню всегда отображается -->
+                <button class="mobile-menu-toggle">
+                    <span class="menu-text">Меню</span>
+                    <span class="menu-icon">
+                        <span class="icon-bar"></span>
+                        <span class="icon-bar"></span>
+                        <span class="icon-bar"></span>
+                    </span>
+                </button>
                 <ul class="navbar-menu">
                     <li><a href="ceny.html">Цены</a></li>
                     <li><a href="potolki.html">Каталог</a></li>


### PR DESCRIPTION
## Summary
- add responsive hamburger markup to site headers
- animate mobile navigation with smooth slide and burger-to-cross icon
- close menu automatically after link click

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68ab1f37757483209fd2d15a4ce8dddd