### PR TITLE
Add mobile dropdown navigation

### DIFF
--- a/akcii.html
+++ b/akcii.html
@@ -41,7 +41,13 @@
         <!-- Навигационное меню -->
         <nav class="navbar-fullwidth">
             <div class="container">
-                <!-- Мобильная кнопка убрана, меню всегда отображается -->
+                <button class="mobile-menu-toggle">Меню
+                    <span class="menu-icon">
+                        <span class="icon-bar"></span>
+                        <span class="icon-bar"></span>
+                        <span class="icon-bar"></span>
+                    </span>
+                </button>
 
                 <ul class="navbar-menu">
                     <li><a href="ceny.html">Цены</a></li>

--- a/ceny.html
+++ b/ceny.html
@@ -35,7 +35,14 @@
         </div>
         <nav class="navbar-fullwidth">
             <div class="container">
-                <!-- Мобильная кнопка убрана, меню всегда отображается -->
+                <button class="mobile-menu-toggle">Меню
+                    <span class="menu-icon">
+                        <span class="icon-bar"></span>
+                        <span class="icon-bar"></span>
+                        <span class="icon-bar"></span>
+                    </span>
+                </button>
+
                 <ul class="navbar-menu">
                     <li><a href="ceny.html">Цены</a></li>
                     <li><a href="potolki.html">Каталог</a></li>

--- a/company.html
+++ b/company.html
@@ -42,7 +42,13 @@
         <!-- Навигационное меню -->
         <nav class="navbar-fullwidth">
             <div class="container">
-                <!-- Мобильная кнопка убрана, меню всегда отображается -->
+                <button class="mobile-menu-toggle">Меню
+                    <span class="menu-icon">
+                        <span class="icon-bar"></span>
+                        <span class="icon-bar"></span>
+                        <span class="icon-bar"></span>
+                    </span>
+                </button>
 
                 <ul class="navbar-menu">
                     <li><a href="ceny.html">Цены</a></li>

--- a/css/style.css
+++ b/css/style.css
@@ -1314,16 +1314,6 @@ body {
 /* Дополнительные стили для улучшений                                */
 /* ------------------------------------------------------------------ */
 
-/* Всегда отображаем горизонтальное меню и скрываем мобильную кнопку */
-.mobile-menu-toggle {
-    display: none !important;
-}
-
-/* Навигационное меню всегда в одну строку */
-.navbar-menu {
-    display: flex !important;
-    flex-direction: row !important;
-}
 
 /* Уточняем размер Instagram-кнопки в отзывах */
 .instagram-link {
@@ -1422,38 +1412,3 @@ body {
     margin: 8px 0;
 }
 
-/* ----------------------------------------------------------
- * Custom overrides for responsive navigation
- *
- * The original design hid the navigation menu on narrow screens and
- * relied on a hamburger icon.  For this project the client wants
- * the menu links to be always visible, even on mobile devices.  The
- * following media query overrides the earlier rules by forcing the
- * menu to display as a flexible row that wraps when necessary.  It
- * also hides the mobile menu toggle completely.
- */
-@media (max-width: 992px) {
-    /* Hide the burger button entirely */
-    .mobile-menu-toggle {
-        display: none !important;
-    }
-    /* Display the menu items in a flex container that wraps */
-    .navbar-menu {
-        display: flex !important;
-        flex-direction: row;
-        flex-wrap: wrap;
-        width: 100%;
-    }
-    /* Each menu item takes half of the row on very small screens */
-    .navbar-menu li {
-        flex: 1 1 50%;
-        text-align: center;
-    }
-    /* Reduce padding and font-size for small screens */
-    .navbar-menu a {
-        padding: 12px 8px;
-        font-size: 15px;
-    }
-}
-
-        }

--- a/index.html
+++ b/index.html
@@ -43,7 +43,13 @@
         <!-- Навигационное меню -->
         <nav class="navbar-fullwidth">
             <div class="container">
-                <!-- Мобильная кнопка убрана, меню всегда отображается -->
+                <button class="mobile-menu-toggle">Меню
+                    <span class="menu-icon">
+                        <span class="icon-bar"></span>
+                        <span class="icon-bar"></span>
+                        <span class="icon-bar"></span>
+                    </span>
+                </button>
 
                 <ul class="navbar-menu">
                     <li><a href="ceny.html">Цены</a></li>

--- a/kontakty.html
+++ b/kontakty.html
@@ -35,7 +35,14 @@
         </div>
         <nav class="navbar-fullwidth">
             <div class="container">
-                <!-- Мобильная кнопка убрана, меню всегда отображается -->
+                <button class="mobile-menu-toggle">Меню
+                    <span class="menu-icon">
+                        <span class="icon-bar"></span>
+                        <span class="icon-bar"></span>
+                        <span class="icon-bar"></span>
+                    </span>
+                </button>
+
                 <ul class="navbar-menu">
                     <li><a href="ceny.html">Цены</a></li>
                     <li><a href="potolki.html">Каталог</a></li>

--- a/otzyvy.html
+++ b/otzyvy.html
@@ -42,7 +42,13 @@
         <!-- Навигационное меню -->
         <nav class="navbar-fullwidth">
             <div class="container">
-                <!-- Мобильная кнопка убрана, меню всегда отображается -->
+                <button class="mobile-menu-toggle">Меню
+                    <span class="menu-icon">
+                        <span class="icon-bar"></span>
+                        <span class="icon-bar"></span>
+                        <span class="icon-bar"></span>
+                    </span>
+                </button>
 
                 <ul class="navbar-menu">
                     <li><a href="ceny.html">Цены</a></li>

--- a/partials/header.html
+++ b/partials/header.html
@@ -21,7 +21,13 @@
         <!-- Навигационное меню -->
         <nav class="navbar-fullwidth">
             <div class="container">
-                
+                <button class="mobile-menu-toggle">Меню
+                    <span class="menu-icon">
+                        <span class="icon-bar"></span>
+                        <span class="icon-bar"></span>
+                        <span class="icon-bar"></span>
+                    </span>
+                </button>
 
                 <ul class="navbar-menu">
                     <li><a href="ceny.html">Цены</a></li>

--- a/potolki.html
+++ b/potolki.html
@@ -35,7 +35,14 @@
         </div>
         <nav class="navbar-fullwidth">
             <div class="container">
-                <!-- Мобильная кнопка убрана, меню всегда отображается -->
+                <button class="mobile-menu-toggle">Меню
+                    <span class="menu-icon">
+                        <span class="icon-bar"></span>
+                        <span class="icon-bar"></span>
+                        <span class="icon-bar"></span>
+                    </span>
+                </button>
+
                 <ul class="navbar-menu">
                     <li><a href="ceny.html">Цены</a></li>
                     <li><a href="potolki.html">Каталог</a></li>

--- a/rphotos.html
+++ b/rphotos.html
@@ -35,7 +35,14 @@
         </div>
         <nav class="navbar-fullwidth">
             <div class="container">
-                <!-- Мобильная кнопка убрана, меню всегда отображается -->
+                <button class="mobile-menu-toggle">Меню
+                    <span class="menu-icon">
+                        <span class="icon-bar"></span>
+                        <span class="icon-bar"></span>
+                        <span class="icon-bar"></span>
+                    </span>
+                </button>
+
                 <ul class="navbar-menu">
                     <li><a href="ceny.html">Цены</a></li>
                     <li><a href="potolki.html">Каталог</a></li>


### PR DESCRIPTION
## Summary
- add "Меню" toggle button to header navigation on all pages
- restore responsive styles so menu appears as dropdown on small screens

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68ade95ba8788320ac59091c89bd6157