### PR TITLE
Fix desktop carousel and adjust mobile image sizing

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1353,6 +1353,19 @@ img {
   border-radius: 10px;
 }
 
+@media (max-width: 576px) {
+  .carousel {
+    max-width: 300px;
+    margin-left: auto;
+    margin-right: auto;
+  }
+
+  .carousel-track img {
+    aspect-ratio: 1 / 1;
+    object-fit: cover;
+  }
+}
+
 
 /* ------------------------------------------------------------------ */
 /* Contact page (kontakty.html)                                       */

--- a/js/work-carousel.js
+++ b/js/work-carousel.js
@@ -13,20 +13,31 @@ document.addEventListener('DOMContentLoaded', () => {
             track.style.transform = `translateX(-${i * 100}%)`;
         }
 
-        let intervalId;
-        const observer = new IntersectionObserver(entries => {
-            entries.forEach(entry => {
-                if (entry.isIntersecting) {
-                    intervalId = setInterval(() => {
-                        index = (index + 1) % total;
-                        showSlide(index);
-                    }, 3000);
-                } else {
-                    clearInterval(intervalId);
-                }
-            });
-        }, { threshold: 0.5 });
+        function startAuto() {
+            return setInterval(() => {
+                index = (index + 1) % total;
+                showSlide(index);
+            }, 3000);
+        }
 
-        observer.observe(carousel);
+        let intervalId;
+        const isDesktop = window.matchMedia('(min-width: 993px)').matches;
+
+        if ('IntersectionObserver' in window && !isDesktop) {
+            const observer = new IntersectionObserver(entries => {
+                entries.forEach(entry => {
+                    if (entry.isIntersecting) {
+                        if (!intervalId) intervalId = startAuto();
+                    } else {
+                        clearInterval(intervalId);
+                        intervalId = null;
+                    }
+                });
+            }, { threshold: 0.5 });
+
+            observer.observe(carousel);
+        } else {
+            intervalId = startAuto();
+        }
     });
 });


### PR DESCRIPTION
## Summary
- Start work carousel automatically on desktop devices, keeping IntersectionObserver for mobile
- Limit carousel width on small screens and force square, cropped images for a compact look

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b75892b5e88320ad9d95b96adca6a0