### PR TITLE
feat: enhance work carousel with centered slide

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1343,14 +1343,21 @@ img {
 }
 
 .carousel-track {
-  display: flex;
-  transition: transform 0.5s ease;
+  position: relative;
+  height: 50vw;
+  max-height: 300px;
 }
 
 .carousel-track img {
+  position: absolute;
+  top: 50%;
+  left: 0;
   width: 100%;
-  flex: 0 0 100%;
+  height: 100%;
+  object-fit: cover;
   border-radius: 10px;
+  transform: translate(0, -50%);
+  transition: transform 0.5s ease, width 0.5s ease;
 }
 
 @media (max-width: 576px) {
@@ -1360,9 +1367,8 @@ img {
     margin-right: auto;
   }
 
-  .carousel-track img {
-    aspect-ratio: 1 / 1;
-    object-fit: cover;
+  .carousel-track {
+    height: 300px;
   }
 }
 

--- a/js/work-carousel.js
+++ b/js/work-carousel.js
@@ -1,26 +1,69 @@
-// Автокарусель для страницы "Наши работы"
+// Автокарусель для страницы "Наши работы" с отображением предыдущего и следующего изображения
 
 document.addEventListener('DOMContentLoaded', () => {
     document.querySelectorAll('.carousel').forEach(carousel => {
         const track = carousel.querySelector('.carousel-track');
-        const slides = track ? track.children : [];
+        const slides = Array.from(track ? track.children : []);
         if (!track || slides.length === 0) return;
 
         let index = 0;
         const total = slides.length;
 
-        function showSlide(i) {
-            track.style.transform = `translateX(-${i * 100}%)`;
+        function update() {
+            const width = carousel.clientWidth;
+            const activeWidth = width * 0.5;
+            const sideWidth = width * 0.2;
+            const activeLeft = (width - activeWidth) / 2;
+            const nextLeft = width - sideWidth;
+            const offRight = width + sideWidth;
+            const offLeft = -sideWidth;
+
+            const prev = (index - 1 + total) % total;
+            const next = (index + 1) % total;
+            const prevPrev = (index - 2 + total) % total;
+
+            slides.forEach((slide, i) => {
+                slide.style.position = 'absolute';
+                slide.style.top = '50%';
+                slide.style.left = '0';
+                slide.style.height = '100%';
+                slide.style.objectFit = 'cover';
+                slide.style.transition = 'transform 0.5s ease, width 0.5s ease';
+
+                if (i === index) {
+                    slide.style.width = `${activeWidth}px`;
+                    slide.style.transform = `translate(${activeLeft}px, -50%)`;
+                    slide.style.zIndex = 2;
+                } else if (i === prev) {
+                    slide.style.width = `${sideWidth}px`;
+                    slide.style.transform = `translate(0px, -50%)`;
+                    slide.style.zIndex = 1;
+                } else if (i === next) {
+                    slide.style.width = `${sideWidth}px`;
+                    slide.style.transform = `translate(${nextLeft}px, -50%)`;
+                    slide.style.zIndex = 1;
+                } else if (i === prevPrev) {
+                    slide.style.width = `${sideWidth}px`;
+                    slide.style.transform = `translate(${offLeft}px, -50%)`;
+                    slide.style.zIndex = 0;
+                } else {
+                    slide.style.width = `${sideWidth}px`;
+                    slide.style.transform = `translate(${offRight}px, -50%)`;
+                    slide.style.zIndex = 0;
+                }
+            });
         }
 
         function startAuto() {
             return setInterval(() => {
                 index = (index + 1) % total;
-                showSlide(index);
+                update();
             }, 3000);
         }
 
         let intervalId;
+        update();
+
         const isDesktop = window.matchMedia('(min-width: 993px)').matches;
 
         if ('IntersectionObserver' in window && !isDesktop) {
@@ -39,5 +82,8 @@ document.addEventListener('DOMContentLoaded', () => {
         } else {
             intervalId = startAuto();
         }
+
+        window.addEventListener('resize', update);
     });
 });
+


### PR DESCRIPTION
## Summary
- make carousel show previous and next images on the sides with the current image centered and larger
- add animated resizing and positioning for smooth transitions

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b75b53630c8320b11ee1757eaff292