### PR TITLE
Ensure carousel images are square and center work section text

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1329,11 +1329,14 @@ img {
   font-size: 1.8rem;
   margin-bottom: 15px;
   color: var(--dark);
+  text-align: center;
 }
 
 .work-section p {
   max-width: 800px;
   line-height: 1.6;
+  margin: 0 auto;
+  text-align: center;
 }
 
 .carousel {
@@ -1352,12 +1355,11 @@ img {
   position: absolute;
   top: 50%;
   left: 0;
-  width: 100%;
-  height: 100%;
   object-fit: cover;
   border-radius: 10px;
   transform: translate(0, -50%);
-  transition: transform 0.5s ease, width 0.5s ease;
+  transition: transform 0.5s ease, width 0.5s ease, height 0.5s ease;
+  aspect-ratio: 1 / 1;
 }
 
 @media (max-width: 576px) {

--- a/js/work-carousel.js
+++ b/js/work-carousel.js
@@ -18,6 +18,8 @@ document.addEventListener('DOMContentLoaded', () => {
             const offRight = width + sideWidth;
             const offLeft = -sideWidth;
 
+            track.style.height = `${activeWidth}px`;
+
             const prev = (index - 1 + total) % total;
             const next = (index + 1) % total;
             const prevPrev = (index - 2 + total) % total;
@@ -26,28 +28,32 @@ document.addEventListener('DOMContentLoaded', () => {
                 slide.style.position = 'absolute';
                 slide.style.top = '50%';
                 slide.style.left = '0';
-                slide.style.height = '100%';
                 slide.style.objectFit = 'cover';
-                slide.style.transition = 'transform 0.5s ease, width 0.5s ease';
+                slide.style.transition = 'transform 0.5s ease, width 0.5s ease, height 0.5s ease';
 
                 if (i === index) {
                     slide.style.width = `${activeWidth}px`;
+                    slide.style.height = `${activeWidth}px`;
                     slide.style.transform = `translate(${activeLeft}px, -50%)`;
                     slide.style.zIndex = 2;
                 } else if (i === prev) {
                     slide.style.width = `${sideWidth}px`;
+                    slide.style.height = `${sideWidth}px`;
                     slide.style.transform = `translate(0px, -50%)`;
                     slide.style.zIndex = 1;
                 } else if (i === next) {
                     slide.style.width = `${sideWidth}px`;
+                    slide.style.height = `${sideWidth}px`;
                     slide.style.transform = `translate(${nextLeft}px, -50%)`;
                     slide.style.zIndex = 1;
                 } else if (i === prevPrev) {
                     slide.style.width = `${sideWidth}px`;
+                    slide.style.height = `${sideWidth}px`;
                     slide.style.transform = `translate(${offLeft}px, -50%)`;
                     slide.style.zIndex = 0;
                 } else {
                     slide.style.width = `${sideWidth}px`;
+                    slide.style.height = `${sideWidth}px`;
                     slide.style.transform = `translate(${offRight}px, -50%)`;
                     slide.style.zIndex = 0;
                 }
@@ -64,9 +70,7 @@ document.addEventListener('DOMContentLoaded', () => {
         let intervalId;
         update();
 
-        const isDesktop = window.matchMedia('(min-width: 993px)').matches;
-
-        if ('IntersectionObserver' in window && !isDesktop) {
+        if ('IntersectionObserver' in window) {
             const observer = new IntersectionObserver(entries => {
                 entries.forEach(entry => {
                     if (entry.isIntersecting) {


### PR DESCRIPTION
## Summary
- Make all carousel slides square and autoplay only when the carousel is in view
- Center work section titles and descriptions

## Testing
- `npm test` (fails: no test specified)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b75ee3d1548320af7dba5ff00f86c2