### PR TITLE
Position calculator icons at edges and keep buttons together

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -396,16 +396,17 @@ img {
 /* Кнопки */
   .calculator-actions {
     display: flex;
-    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
     gap: 15px;
     margin-top: 30px;
-    justify-content: center;
   }
 
-  .calc-item {
+  .calc-buttons {
     display: flex;
+    gap: 15px;
     align-items: center;
-    gap: 10px;
+    justify-content: center;
   }
 
   .calc-label {
@@ -421,8 +422,8 @@ img {
   }
 
   .calc-icon {
-    width: 60px;
-    height: 60px;
+    width: 100px;
+    height: 100px;
   }
 
 .btn {
@@ -782,10 +783,12 @@ img {
 
     .calculator-actions {
       flex-direction: column;
+      gap: 15px;
     }
 
-    .calc-item {
+    .calc-buttons {
       flex-direction: column;
+      width: 100%;
     }
 
     .calc-label {

--- a/index.html
+++ b/index.html
@@ -106,19 +106,17 @@
                 </li>
             </ul>
             <div class="calculator-actions" data-aos="zoom-in" data-aos-delay="400">
-                <div class="calc-item calc-item-left">
-                    <div class="calc-label">
-                        <img src="img/bauf.svg" alt="BAUF логотип" class="calc-icon">
-                        <span class="calc-text">Немецкое качество</span>
-                    </div>
-                    <button class="btn" id="scrollToCalculator">Расчитать стоимость</button>
+                <div class="calc-label">
+                    <img src="img/bauf.svg" alt="BAUF логотип" class="calc-icon">
+                    <span class="calc-text">Немецкое качество</span>
                 </div>
-                <div class="calc-item calc-item-right">
+                <div class="calc-buttons">
+                    <button class="btn" id="scrollToCalculator">Расчитать стоимость</button>
                     <button class="btn btn-secondary" id="openModal">Записаться на замер</button>
-                    <div class="calc-label">
-                        <img src="img/eco-friendly.png" alt="Eco-friendly значок" class="calc-icon">
-                        <span class="calc-text">Абсолютно безопасно и экологично. Подтверждено европейскими сертификатами.</span>
-                    </div>
+                </div>
+                <div class="calc-label">
+                    <img src="img/eco-friendly.png" alt="Eco-friendly значок" class="calc-icon">
+                    <span class="calc-text">Абсолютно безопасно и экологично. Подтверждено европейскими сертификатами.</span>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- Place BAUF and eco-friendly icons on opposite screen edges with both action buttons centered between them
- Enlarge calculator icons to 100px and adjust layout styles for desktop and mobile

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bf46c443d4832097755d130329b22e