### PR TITLE
Center calculator buttons and enlarge BAUF logo

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -395,11 +395,19 @@ img {
 
 /* Кнопки */
   .calculator-actions {
-    display: flex;
+    display: grid;
+    grid-template-columns: 1fr auto 1fr;
     align-items: center;
-    justify-content: space-between;
     gap: 15px;
     margin-top: 30px;
+  }
+
+  .calculator-actions .calc-label:first-of-type {
+    justify-self: start;
+  }
+
+  .calculator-actions .calc-label:last-of-type {
+    justify-self: end;
   }
 
   .calc-buttons {
@@ -424,6 +432,11 @@ img {
   .calc-icon {
     width: 100px;
     height: 100px;
+  }
+
+  .bauf-logo {
+    width: 200px;
+    height: 200px;
   }
 
 .btn {
@@ -782,7 +795,9 @@ img {
     }
 
     .calculator-actions {
+      display: flex;
       flex-direction: column;
+      align-items: center;
       gap: 15px;
     }
 

--- a/index.html
+++ b/index.html
@@ -107,7 +107,7 @@
             </ul>
             <div class="calculator-actions" data-aos="zoom-in" data-aos-delay="400">
                 <div class="calc-label">
-                    <img src="img/bauf.svg" alt="BAUF логотип" class="calc-icon">
+                    <img src="img/bauf.svg" alt="BAUF логотип" class="calc-icon bauf-logo">
                     <span class="calc-text">Немецкое качество</span>
                 </div>
                 <div class="calc-buttons">
@@ -116,7 +116,7 @@
                 </div>
                 <div class="calc-label">
                     <img src="img/eco-friendly.png" alt="Eco-friendly значок" class="calc-icon">
-                    <span class="calc-text">Абсолютно безопасно и экологично. Подтверждено европейскими сертификатами.</span>
+                    <span class="calc-text">Абсолютно безопасно и экологично.<br>Подтверждено европейскими сертификатами.</span>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- Double BAUF logo size with dedicated class and split eco description into two lines
- Rework calculator actions layout using CSS grid to keep button block centered
- Ensure mobile view stacks actions vertically

## Testing
- `npm test` *(fails: command not found: npm)*
- `apt-get update` *(fails: repository not signed, 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bf4905a5b0832091572664918cff12