### PR TITLE
Move hero badges next to benefits list

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -367,10 +367,19 @@ img {
   color: var(--primary);
 }
 
+.main-highlights {
+  display: grid;
+  gap: 30px;
+  margin: 40px auto 0;
+  width: 100%;
+  max-width: 1000px;
+  justify-items: center;
+}
+
 .benefits-list {
   list-style: none;
   padding: 0;
-  margin: 40px auto;
+  margin: 0;
   max-width: 300px;
   display: block;
 }
@@ -393,21 +402,24 @@ img {
   object-fit: contain;
 }
 
+@media (min-width: 992px) {
+  .main-highlights {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    align-items: start;
+  }
+
+  .main-highlights .benefits-list {
+    justify-self: start;
+  }
+}
+
 /* Кнопки */
   .calculator-actions {
-    display: grid;
-    grid-template-columns: 1fr auto 1fr;
+    display: flex;
+    justify-content: center;
     align-items: center;
     gap: 15px;
     margin-top: 30px;
-  }
-
-  .calculator-actions .calc-label:first-of-type {
-    justify-self: start;
-  }
-
-  .calculator-actions .calc-label:last-of-type {
-    justify-self: end;
   }
 
   .calc-buttons {

--- a/index.html
+++ b/index.html
@@ -83,40 +83,42 @@
     <section class="main" data-aos="fade-down" data-aos-delay="50">
         <div class="container">
             <h1>Натяжные потолки в Анталии <br> <span> от 20$ за м² под ключ</span> <br> Работаем по всему региону!</h1>
-            <ul class="benefits-list">
-                <li data-aos="zoom-in" data-aos-delay="150">
-                    <img src="img/checkmark.svg" alt="Немецкие полотна BAUF" class="check-icon">
-                    Немецкие полотна BAUF
-                </li>
-                <li data-aos="zoom-in" data-aos-delay="200">
-                    <img src="img/checkmark.svg" alt="Без пыли и грязи" class="check-icon">
-                    Без пыли и грязи
-                </li>
-                <li data-aos="zoom-in" data-aos-delay="250">
-                    <img src="img/checkmark.svg" alt="Потолок за 1 день" class="check-icon">
-                    Потолок за 1 день
-                </li>
-                <li data-aos="zoom-in" data-aos-delay="300">
-                    <img src="img/checkmark.svg" alt="Гарантия 2 года" class="check-icon">
-                    Гарантия 2 года
-                </li>
-                <li data-aos="zoom-in" data-aos-delay="350">
-                    <img src="img/checkmark.svg" alt="Бесплатное обслуживание" class="check-icon">
-                    Бесплатное обслуживание
-                </li>
-            </ul>
-            <div class="calculator-actions" data-aos="zoom-in" data-aos-delay="400">
+            <div class="main-highlights">
+                <ul class="benefits-list">
+                    <li data-aos="zoom-in" data-aos-delay="150">
+                        <img src="img/checkmark.svg" alt="Немецкие полотна BAUF" class="check-icon">
+                        Немецкие полотна BAUF
+                    </li>
+                    <li data-aos="zoom-in" data-aos-delay="200">
+                        <img src="img/checkmark.svg" alt="Без пыли и грязи" class="check-icon">
+                        Без пыли и грязи
+                    </li>
+                    <li data-aos="zoom-in" data-aos-delay="250">
+                        <img src="img/checkmark.svg" alt="Потолок за 1 день" class="check-icon">
+                        Потолок за 1 день
+                    </li>
+                    <li data-aos="zoom-in" data-aos-delay="300">
+                        <img src="img/checkmark.svg" alt="Гарантия 2 года" class="check-icon">
+                        Гарантия 2 года
+                    </li>
+                    <li data-aos="zoom-in" data-aos-delay="350">
+                        <img src="img/checkmark.svg" alt="Бесплатное обслуживание" class="check-icon">
+                        Бесплатное обслуживание
+                    </li>
+                </ul>
                 <div class="calc-label">
                     <img src="img/bauf.svg" alt="BAUF логотип" class="calc-icon bauf-logo">
                     <span class="calc-text">Немецкое качество</span>
                 </div>
-                <div class="calc-buttons">
-                    <button class="btn" id="scrollToCalculator">Расчитать стоимость</button>
-                    <button class="btn btn-secondary" id="openModal">Записаться на замер</button>
-                </div>
                 <div class="calc-label">
                     <img src="img/eco-friendly.png" alt="Eco-friendly значок" class="calc-icon">
                     <span class="calc-text">Абсолютно безопасно и экологично.<br>Подтверждено европейскими сертификатами.</span>
+                </div>
+            </div>
+            <div class="calculator-actions" data-aos="zoom-in" data-aos-delay="400">
+                <div class="calc-buttons">
+                    <button class="btn" id="scrollToCalculator">Расчитать стоимость</button>
+                    <button class="btn btn-secondary" id="openModal">Записаться на замер</button>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- reposition the BAUF and eco highlights to share a new hero highlights row with the benefits list
- adjust hero styling so the highlights align in a three-column grid on large screens and center the action buttons below

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c8849c67248320b558c6ae1750904e