### PR TITLE
Align hero badges beside benefit list

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -404,8 +404,8 @@ img {
 
 @media (min-width: 992px) {
   .main-highlights {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-    align-items: start;
+    grid-template-columns: auto minmax(0, 1fr) auto;
+    align-items: center;
   }
 
   .main-highlights .benefits-list {
@@ -435,6 +435,26 @@ img {
     align-items: center;
     text-align: center;
     gap: 8px;
+  }
+
+  .main-highlights .calc-label {
+    align-self: center;
+  }
+
+  .calc-label--eco {
+    max-width: 280px;
+  }
+
+  @media (min-width: 992px) {
+    .calc-label--bauf {
+      justify-self: end;
+    }
+
+    .calc-label--eco {
+      align-items: flex-start;
+      text-align: left;
+      justify-self: start;
+    }
   }
 
   .calc-text {

--- a/index.html
+++ b/index.html
@@ -84,6 +84,10 @@
         <div class="container">
             <h1>Натяжные потолки в Анталии <br> <span> от 20$ за м² под ключ</span> <br> Работаем по всему региону!</h1>
             <div class="main-highlights">
+                <div class="calc-label calc-label--bauf">
+                    <img src="img/bauf.svg" alt="BAUF логотип" class="calc-icon bauf-logo">
+                    <span class="calc-text">Немецкое качество</span>
+                </div>
                 <ul class="benefits-list">
                     <li data-aos="zoom-in" data-aos-delay="150">
                         <img src="img/checkmark.svg" alt="Немецкие полотна BAUF" class="check-icon">
@@ -106,11 +110,7 @@
                         Бесплатное обслуживание
                     </li>
                 </ul>
-                <div class="calc-label">
-                    <img src="img/bauf.svg" alt="BAUF логотип" class="calc-icon bauf-logo">
-                    <span class="calc-text">Немецкое качество</span>
-                </div>
-                <div class="calc-label">
+                <div class="calc-label calc-label--eco">
                     <img src="img/eco-friendly.png" alt="Eco-friendly значок" class="calc-icon">
                     <span class="calc-text">Абсолютно безопасно и экологично.<br>Подтверждено европейскими сертификатами.</span>
                 </div>


### PR DESCRIPTION
## Summary
- reorder the hero highlights so the BAUF and eco badges flank the benefits list
- adjust the hero grid layout to keep the badges aligned alongside the benefits on large screens

## Testing
- no tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c88b87d1e0832099140b53ee8370f9