### PR TITLE
Adjust Bauf badge height to match eco label

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -467,8 +467,8 @@ img {
   }
 
   .bauf-logo {
-    width: 200px;
-    height: 200px;
+    width: 100px;
+    height: 100px;
   }
 
 .btn {


### PR DESCRIPTION
## Summary
- update the Bauf logo dimensions so it matches the eco label height in the hero highlights

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c88d5b516483209e5351b6f426d4dd