### PR TITLE
Adjust calculator labels layout

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -431,10 +431,11 @@ img {
 
   .calc-label {
     display: flex;
-    flex-direction: row;
+    flex-direction: column;
     align-items: center;
-    text-align: left;
-    gap: 16px;
+    text-align: center;
+    justify-content: center;
+    gap: 12px;
   }
 
   .main-highlights .calc-label {


### PR DESCRIPTION
## Summary
- place the BAUF and eco calculator captions under their respective logos by switching the label layout to a centered column

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c891a511088320bf62d268ef791490