### PR TITLE
Align hero highlight text under logos

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -456,9 +456,12 @@ img {
     }
   }
 
-  .calc-text {
-    font-size: 14px;
-  }
+    .calc-text {
+      font-size: 14px;
+      margin: 0;
+      text-align: center;
+      line-height: 1.4;
+    }
 
   .calc-icon {
     width: 100px;

--- a/index.html
+++ b/index.html
@@ -86,7 +86,7 @@
             <div class="main-highlights">
                 <div class="calc-label calc-label--bauf">
                     <img src="img/bauf.svg" alt="BAUF логотип" class="calc-icon bauf-logo">
-                    <span class="calc-text">Немецкое качество</span>
+                    <p class="calc-text">Немецкое качество</p>
                 </div>
                 <ul class="benefits-list">
                     <li data-aos="zoom-in" data-aos-delay="150">
@@ -112,7 +112,7 @@
                 </ul>
                 <div class="calc-label calc-label--eco">
                     <img src="img/eco-friendly.png" alt="Eco-friendly значок" class="calc-icon">
-                    <span class="calc-text">Абсолютно безопасно и экологично.<br>Подтверждено европейскими сертификатами.</span>
+                    <p class="calc-text">Абсолютно безопасно и экологично.<br>Подтверждено европейскими сертификатами.</p>
                 </div>
             </div>
             <div class="calculator-actions" data-aos="zoom-in" data-aos-delay="400">


### PR DESCRIPTION
## Summary
- place the BAUF highlight copy under its logo and center the ECO description beneath its icon by switching to block-level markup
- center and reset spacing on the hero highlight text style so the captions sit tightly under the graphics

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c893a7a6448320801f971da01b3bd7