### PR TITLE
Center benefits list in hero section

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -379,7 +379,7 @@ img {
 .benefits-list {
   list-style: none;
   padding: 0;
-  margin: 0;
+  margin: 0 auto;
   max-width: 300px;
   display: block;
 }
@@ -409,7 +409,7 @@ img {
   }
 
   .main-highlights .benefits-list {
-    justify-self: start;
+    justify-self: center;
   }
 }
 


### PR DESCRIPTION
## Summary
- center the benefits list block by using automatic horizontal margins
- align the benefits list to the center within the large-screen grid layout

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c895c4fb3883208bdae9a710c5c756