### PR TITLE
Update hero highlights with eco, BAUF, and certificates cards

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -376,6 +376,20 @@ img {
   justify-items: center;
 }
 
+.feature-cards {
+  display: grid;
+  gap: 20px;
+  width: 100%;
+  justify-items: center;
+  align-items: start;
+}
+
+@media (min-width: 576px) {
+  .feature-cards {
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  }
+}
+
 .benefits-list {
   list-style: none;
   padding: 0;
@@ -402,17 +416,6 @@ img {
   object-fit: contain;
 }
 
-@media (min-width: 992px) {
-  .main-highlights {
-    grid-template-columns: auto minmax(0, 1fr) auto;
-    align-items: center;
-  }
-
-  .main-highlights .benefits-list {
-    justify-self: center;
-  }
-}
-
 /* Кнопки */
   .calculator-actions {
     display: flex;
@@ -436,32 +439,22 @@ img {
     text-align: center;
     justify-content: center;
     gap: 12px;
+    width: 100%;
+    max-width: 260px;
   }
 
-  .main-highlights .calc-label {
-    align-self: center;
+  .calc-text {
+    font-size: 14px;
+    margin: 0;
+    text-align: center;
+    line-height: 1.4;
   }
 
-  .calc-label--eco {
-    max-width: 280px;
+  .calc-label--eco,
+  .calc-label--bauf,
+  .calc-label--certificates {
+    justify-self: center;
   }
-
-  @media (min-width: 992px) {
-    .calc-label--bauf {
-      justify-self: end;
-    }
-
-    .calc-label--eco {
-      justify-self: start;
-    }
-  }
-
-    .calc-text {
-      font-size: 14px;
-      margin: 0;
-      text-align: center;
-      line-height: 1.4;
-    }
 
   .calc-icon {
     width: 100px;

--- a/index.html
+++ b/index.html
@@ -84,9 +84,19 @@
         <div class="container">
             <h1>Натяжные потолки в Анталии <br> <span> от 20$ за м² под ключ</span> <br> Работаем по всему региону!</h1>
             <div class="main-highlights">
-                <div class="calc-label calc-label--bauf">
-                    <img src="img/bauf.svg" alt="BAUF логотип" class="calc-icon bauf-logo">
-                    <p class="calc-text">Немецкое качество</p>
+                <div class="feature-cards">
+                    <div class="calc-label calc-label--eco">
+                        <img src="img/eco-friendly.png" alt="Eco-friendly значок" class="calc-icon">
+                        <p class="calc-text">Абсолютно безопасно и экологично</p>
+                    </div>
+                    <div class="calc-label calc-label--bauf">
+                        <img src="img/bauf.svg" alt="BAUF логотип" class="calc-icon bauf-logo">
+                        <p class="calc-text">Немецкое качество</p>
+                    </div>
+                    <div class="calc-label calc-label--certificates">
+                        <img src="img/checkmark.svg" alt="Европейские сертификаты" class="calc-icon">
+                        <p class="calc-text">Европейские сертификаты</p>
+                    </div>
                 </div>
                 <ul class="benefits-list">
                     <li data-aos="zoom-in" data-aos-delay="150">
@@ -110,10 +120,6 @@
                         Бесплатное обслуживание
                     </li>
                 </ul>
-                <div class="calc-label calc-label--eco">
-                    <img src="img/eco-friendly.png" alt="Eco-friendly значок" class="calc-icon">
-                    <p class="calc-text">Абсолютно безопасно и экологично.<br>Подтверждено европейскими сертификатами.</p>
-                </div>
             </div>
             <div class="calculator-actions" data-aos="zoom-in" data-aos-delay="400">
                 <div class="calc-buttons">


### PR DESCRIPTION
## Summary
- reorganized the hero highlight area to show eco, BAUF, and certificates cards alongside the existing benefits list
- refreshed copy for the eco and certificate highlights and kept the core benefit bullet list intact
- updated styling to lay out the three cards responsively and keep the hero content centered

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68c9d3ee583c8320802fd86ad7a9fca6