### PR TITLE
Adjust mobile menu layout

### DIFF
--- a/akcii.html
+++ b/akcii.html
@@ -41,8 +41,8 @@
         <!-- Навигационное меню -->
         <nav class="navbar-fullwidth">
             <div class="container">
-                <button class="mobile-menu-toggle">Меню
-                    <span class="menu-icon">
+                <button class="mobile-menu-toggle" type="button" aria-label="Открыть меню">
+                    <span class="menu-icon" aria-hidden="true">
                         <span class="icon-bar"></span>
                         <span class="icon-bar"></span>
                         <span class="icon-bar"></span>

--- a/ceny.html
+++ b/ceny.html
@@ -36,8 +36,8 @@
         </div>
         <nav class="navbar-fullwidth">
             <div class="container">
-                <button class="mobile-menu-toggle">Меню
-                    <span class="menu-icon">
+                <button class="mobile-menu-toggle" type="button" aria-label="Открыть меню">
+                    <span class="menu-icon" aria-hidden="true">
                         <span class="icon-bar"></span>
                         <span class="icon-bar"></span>
                         <span class="icon-bar"></span>

--- a/company.html
+++ b/company.html
@@ -42,8 +42,8 @@
         <!-- Навигационное меню -->
         <nav class="navbar-fullwidth">
             <div class="container">
-                <button class="mobile-menu-toggle">Меню
-                    <span class="menu-icon">
+                <button class="mobile-menu-toggle" type="button" aria-label="Открыть меню">
+                    <span class="menu-icon" aria-hidden="true">
                         <span class="icon-bar"></span>
                         <span class="icon-bar"></span>
                         <span class="icon-bar"></span>

--- a/css/style.css
+++ b/css/style.css
@@ -122,6 +122,10 @@ img {
 .navbar-fullwidth .container {
   padding: 0;
   position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0;
 }
 
 .navbar-menu {
@@ -1477,6 +1481,13 @@ img {
 
 /* Обновляем медиа-запросы для навигационного меню */
 @media (max-width: 992px) {
+  .navbar-fullwidth .container {
+    flex-direction: column;
+    align-items: stretch;
+    justify-content: flex-start;
+    gap: 0;
+  }
+
   .mobile-menu-toggle {
     display: flex;
     flex-direction: column;
@@ -1492,6 +1503,7 @@ img {
     display: none;
     flex-direction: column;
     width: 100%;
+    margin-top: 10px;
   }
 
   .navbar-menu.show {
@@ -1506,6 +1518,12 @@ img {
 
 /* Горизонтальное меню для альбомной ориентации на мобильных */
 @media (max-width: 992px) and (orientation: landscape) {
+  .navbar-fullwidth .container {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+
   .mobile-menu-toggle {
     display: none;
   }
@@ -1516,6 +1534,7 @@ img {
     flex-wrap: nowrap;
     overflow-x: auto;
     -webkit-overflow-scrolling: touch;
+    margin-top: 0;
   }
 
   .navbar-menu li {

--- a/index.html
+++ b/index.html
@@ -59,8 +59,8 @@
         <!-- Навигационное меню -->
         <nav class="navbar-fullwidth">
             <div class="container">
-                <button class="mobile-menu-toggle">Меню
-                    <span class="menu-icon">
+                <button class="mobile-menu-toggle" type="button" aria-label="Открыть меню">
+                    <span class="menu-icon" aria-hidden="true">
                         <span class="icon-bar"></span>
                         <span class="icon-bar"></span>
                         <span class="icon-bar"></span>

--- a/kontakty.html
+++ b/kontakty.html
@@ -35,8 +35,8 @@
         </div>
         <nav class="navbar-fullwidth">
             <div class="container">
-                <button class="mobile-menu-toggle">Меню
-                    <span class="menu-icon">
+                <button class="mobile-menu-toggle" type="button" aria-label="Открыть меню">
+                    <span class="menu-icon" aria-hidden="true">
                         <span class="icon-bar"></span>
                         <span class="icon-bar"></span>
                         <span class="icon-bar"></span>

--- a/otzyvy.html
+++ b/otzyvy.html
@@ -42,8 +42,8 @@
         <!-- Навигационное меню -->
         <nav class="navbar-fullwidth">
             <div class="container">
-                <button class="mobile-menu-toggle">Меню
-                    <span class="menu-icon">
+                <button class="mobile-menu-toggle" type="button" aria-label="Открыть меню">
+                    <span class="menu-icon" aria-hidden="true">
                         <span class="icon-bar"></span>
                         <span class="icon-bar"></span>
                         <span class="icon-bar"></span>

--- a/partials/header.html
+++ b/partials/header.html
@@ -21,8 +21,8 @@
         <!-- Навигационное меню -->
         <nav class="navbar-fullwidth">
             <div class="container">
-                <button class="mobile-menu-toggle">Меню
-                    <span class="menu-icon">
+                <button class="mobile-menu-toggle" type="button" aria-label="Открыть меню">
+                    <span class="menu-icon" aria-hidden="true">
                         <span class="icon-bar"></span>
                         <span class="icon-bar"></span>
                         <span class="icon-bar"></span>

--- a/potolki.html
+++ b/potolki.html
@@ -36,8 +36,8 @@
         </div>
         <nav class="navbar-fullwidth">
             <div class="container">
-                <button class="mobile-menu-toggle">Меню
-                    <span class="menu-icon">
+                <button class="mobile-menu-toggle" type="button" aria-label="Открыть меню">
+                    <span class="menu-icon" aria-hidden="true">
                         <span class="icon-bar"></span>
                         <span class="icon-bar"></span>
                         <span class="icon-bar"></span>

--- a/rphotos.html
+++ b/rphotos.html
@@ -35,8 +35,8 @@
         </div>
         <nav class="navbar-fullwidth">
             <div class="container">
-                <button class="mobile-menu-toggle">Меню
-                    <span class="menu-icon">
+                <button class="mobile-menu-toggle" type="button" aria-label="Открыть меню">
+                    <span class="menu-icon" aria-hidden="true">
                         <span class="icon-bar"></span>
                         <span class="icon-bar"></span>
                         <span class="icon-bar"></span>


### PR DESCRIPTION
## Summary
- remove the "Меню" label from the mobile navigation toggle and add an aria-label so the closed state only shows the icon
- update mobile flex rules so the toggle stacks above the menu items in portrait orientation while keeping the horizontal layout in landscape

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d12e2e18c88320bb7731f41920fb9c