### PR TITLE
Adjust mobile carousel layout

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1450,14 +1450,14 @@ img {
 }
 
 @media (max-width: 576px) {
-  .carousel {
-    max-width: 300px;
-    margin-left: auto;
-    margin-right: auto;
+  .work-section .carousel {
+    width: 100vw;
+    max-width: none;
+    margin-left: calc((100% - 100vw) / 2);
   }
 
   .carousel-track {
-    height: 300px;
+    height: auto;
   }
 }
 

--- a/js/work-carousel.js
+++ b/js/work-carousel.js
@@ -11,8 +11,11 @@ document.addEventListener('DOMContentLoaded', () => {
 
         function update() {
             const width = carousel.clientWidth;
-            const activeWidth = width * 0.5;
-            const sideWidth = width * 0.2;
+            const isMobile = window.innerWidth <= 576;
+            const activeRatio = isMobile ? 0.7 : 0.5;
+            const sideRatio = isMobile ? 0.15 : 0.2;
+            const activeWidth = width * activeRatio;
+            const sideWidth = width * sideRatio;
             const activeLeft = (width - activeWidth) / 2;
             const nextLeft = width - sideWidth;
             const offRight = width + sideWidth;


### PR DESCRIPTION
## Summary
- allow the gallery carousel to span the full viewport width on mobile and drop fixed sizing
- update the carousel script to use a 70/15/15 width ratio for the active and side slides on small screens while keeping the desktop behavior

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d13a1a46bc8320a0e6bbb497116425