### PR TITLE
Redesign contact section

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1512,16 +1512,111 @@ img {
 /* ------------------------------------------------------------------ */
 
 .contact-info {
-  font-size: 1rem;
   color: var(--dark);
-  line-height: 1.6;
-  max-width: 600px;
-  margin: 0 auto;
-  margin-bottom: 30px;
+  max-width: 880px;
+  margin: 0 auto 60px;
 }
 
-.contact-info p {
-  margin: 8px 0;
+.contact-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+}
+
+.contact-card {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 20px 22px;
+  background: #fff;
+  border-radius: 18px;
+  border: 1px solid rgba(0, 0, 0, 0.05);
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.08);
+  text-decoration: none;
+  color: inherit;
+  transition: transform 0.3s ease, box-shadow 0.3s ease, border-color 0.3s ease;
+}
+
+.contact-card:hover {
+  transform: translateY(-6px);
+  box-shadow: 0 20px 32px rgba(0, 0, 0, 0.12);
+  border-color: rgba(255, 139, 68, 0.35);
+}
+
+.contact-card-icon {
+  width: 52px;
+  height: 52px;
+  border-radius: 16px;
+  background: linear-gradient(135deg, rgba(255, 139, 68, 0.2), rgba(255, 139, 68, 0.05));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.contact-card-icon img {
+  width: 28px;
+  height: 28px;
+}
+
+.contact-card-letter {
+  font-size: 26px;
+}
+
+.contact-card-content {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.contact-card-label {
+  font-weight: 700;
+  font-size: 1.05rem;
+}
+
+.contact-card-value {
+  font-weight: 500;
+  color: #666;
+}
+
+.contact-meta {
+  margin-top: 40px;
+  display: grid;
+  gap: 16px;
+}
+
+.contact-meta-item {
+  background: #fff;
+  border-radius: 16px;
+  padding: 18px 22px;
+  border-left: 4px solid var(--primary);
+  box-shadow: 0 10px 26px rgba(0, 0, 0, 0.08);
+}
+
+.contact-meta-label {
+  display: block;
+  font-weight: 700;
+  margin-bottom: 6px;
+  text-transform: uppercase;
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  color: var(--primary);
+}
+
+.contact-meta-value {
+  font-weight: 500;
+  color: var(--dark);
+}
+
+@media (max-width: 576px) {
+  .contact-card {
+    padding: 18px;
+  }
+
+  .contact-card-icon {
+    width: 46px;
+    height: 46px;
+  }
 }
 
 /* Обновляем медиа-запросы для навигационного меню */

--- a/kontakty.html
+++ b/kontakty.html
@@ -71,15 +71,63 @@
             <h1 class="page-title">Контакты</h1>
             <p class="section-subtitle">Свяжитесь с нами удобным для вас способом. Мы с удовольствием ответим на все вопросы и договоримся о бесплатном замере.</p>
             <div class="contact-info">
-                <p><strong>Телефон:</strong> <a href="tel:+905348287110">+90 534 828 71 10</a></p>
-                <p><strong>Адрес:</strong> <a href="https://maps.app.goo.gl/WiW8eAqWNGsCCrF59" target="_blank" rel="noopener">Antalya, Bahçelievler, 137. Sk. No:5</a></p>
-                <p><strong>Сайт:</strong> antalya-potolok.com</p>
-                <p><strong>Время работы:</strong> Пн‑Пт: 9:00 – 19:00; Сб: 10:00 – 16:00; Вс: выходной</p>
-                <p><strong>Мы в соцсетях:</strong>
-                    <a href="https://instagram.com/antalya_potolok" target="_blank">Instagram</a>,
-                    <a href="https://t.me/antalya_potolki" target="_blank">Telegram</a>,
-                    <a href="https://wa.me/905348287110" target="_blank">WhatsApp</a>
-                </p>
+                <div class="contact-grid">
+                    <a class="contact-card" href="https://wa.me/905348287110" target="_blank" rel="noopener">
+                        <span class="contact-card-icon">
+                            <img src="img/whatsapp.svg" alt="WhatsApp Antalya Potolok">
+                        </span>
+                        <span class="contact-card-content">
+                            <span class="contact-card-label">WhatsApp</span>
+                            <span class="contact-card-value">Написать в WhatsApp</span>
+                        </span>
+                    </a>
+                    <a class="contact-card" href="https://instagram.com/antalya_potolok" target="_blank" rel="noopener">
+                        <span class="contact-card-icon">
+                            <img src="img/instagram.svg" alt="Instagram Antalya Potolok">
+                        </span>
+                        <span class="contact-card-content">
+                            <span class="contact-card-label">Instagram</span>
+                            <span class="contact-card-value">@antalya_potolok</span>
+                        </span>
+                    </a>
+                    <a class="contact-card" href="https://t.me/antalya_potolki" target="_blank" rel="noopener">
+                        <span class="contact-card-icon">
+                            <img src="img/telegram.svg" alt="Telegram Antalya Potolok">
+                        </span>
+                        <span class="contact-card-content">
+                            <span class="contact-card-label">Telegram</span>
+                            <span class="contact-card-value">@antalya_potolki</span>
+                        </span>
+                    </a>
+                    <a class="contact-card" href="tel:+905348287110">
+                        <span class="contact-card-icon">
+                            <span class="contact-card-letter">☎</span>
+                        </span>
+                        <span class="contact-card-content">
+                            <span class="contact-card-label">Телефон</span>
+                            <span class="contact-card-value">+90 534 828 71 10</span>
+                        </span>
+                    </a>
+                    <a class="contact-card" href="https://maps.app.goo.gl/WiW8eAqWNGsCCrF59" target="_blank" rel="noopener">
+                        <span class="contact-card-icon">
+                            <span class="contact-card-letter">📍</span>
+                        </span>
+                        <span class="contact-card-content">
+                            <span class="contact-card-label">Адрес</span>
+                            <span class="contact-card-value">Antalya, Bahçelievler, 137. Sk. No:5</span>
+                        </span>
+                    </a>
+                </div>
+                <div class="contact-meta">
+                    <div class="contact-meta-item">
+                        <span class="contact-meta-label">Работаем</span>
+                        <span class="contact-meta-value">Пн‑Пт: 9:00 – 19:00 · Сб: 10:00 – 16:00 · Вс: выходной</span>
+                    </div>
+                    <div class="contact-meta-item">
+                        <span class="contact-meta-label">Сайт</span>
+                        <span class="contact-meta-value">antalya-potolok.com</span>
+                    </div>
+                </div>
             </div>
             <div class="promo-actions">
                 <button class="btn" id="openModal">Заказать звонок</button>


### PR DESCRIPTION
## Summary
- reworked the kontakty.html contact section into a grid of stylized cards prioritizing WhatsApp, Instagram, Telegram, phone, and address links
- added tailored styles for the new contact grid and meta blocks to match the existing site aesthetics and remove default blue link styling

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68e298718444832092eff23b65def2ff