### PR TITLE
Send calculator requests to Telegram

### DIFF
--- a/index.html
+++ b/index.html
@@ -205,7 +205,7 @@
                 <label for="phone">Телефон</label>
                 <input type="tel" id="phone" required>
             </div>
-            <button type="button" class="btn" onclick="sendToGoogleSheets()">Отправить</button>
+            <button type="button" class="btn" onclick="sendCalculationToTelegram()">Отправить</button>
         </div>
     </div>
 


### PR DESCRIPTION
## Summary
- send calculator lead submissions to Telegram using the existing bot credentials
- include calculation parameters and totals in the Telegram message and prevent sending before a calculation runs

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e2bd47fae08320b190409fc97a8a0b