### PR TITLE
Enable Telegram notifications for all modal lead forms

### DIFF
--- a/akcii.html
+++ b/akcii.html
@@ -149,14 +149,14 @@
         <div class="modal-content">
             <span class="close">&times;</span>
             <h3>Оставьте заявку</h3>
-            <form>
+            <form class="modal-form" data-telegram-form data-form-source="Модальная форма">
                 <div class="form-group">
                     <label for="modal-name">Ваше имя</label>
-                    <input type="text" id="modal-name" placeholder="Ваше имя" required>
+                    <input type="text" id="modal-name" name="name" placeholder="Ваше имя" required>
                 </div>
                 <div class="form-group">
                     <label for="modal-phone">Телефон</label>
-                    <input type="tel" id="modal-phone" placeholder="Телефон" required>
+                    <input type="tel" id="modal-phone" name="phone" placeholder="Телефон" required>
                 </div>
                 <button type="submit" class="btn">Отправить</button>
             </form>

--- a/ceny.html
+++ b/ceny.html
@@ -150,14 +150,14 @@
         <div class="modal-content">
             <span class="close">&times;</span>
             <h3>Оставьте заявку</h3>
-            <form>
+            <form class="modal-form" data-telegram-form data-form-source="Модальная форма">
                 <div class="form-group">
                     <label for="modal-name">Ваше имя</label>
-                    <input type="text" id="modal-name" placeholder="Ваше имя" required>
+                    <input type="text" id="modal-name" name="name" placeholder="Ваше имя" required>
                 </div>
                 <div class="form-group">
                     <label for="modal-phone">Телефон</label>
-                    <input type="tel" id="modal-phone" placeholder="Телефон" required>
+                    <input type="tel" id="modal-phone" name="phone" placeholder="Телефон" required>
                 </div>
                 <button type="submit" class="btn">Отправить</button>
             </form>

--- a/company.html
+++ b/company.html
@@ -196,14 +196,14 @@
         <div class="modal-content">
             <span class="close">&times;</span>
             <h3>Оставьте заявку</h3>
-            <form>
+            <form class="modal-form" data-telegram-form data-form-source="Модальная форма">
                 <div class="form-group">
                     <label for="modal-name">Ваше имя</label>
-                    <input type="text" id="modal-name" placeholder="Ваше имя" required>
+                    <input type="text" id="modal-name" name="name" placeholder="Ваше имя" required>
                 </div>
                 <div class="form-group">
                     <label for="modal-phone">Телефон</label>
-                    <input type="tel" id="modal-phone" placeholder="Телефон" required>
+                    <input type="tel" id="modal-phone" name="phone" placeholder="Телефон" required>
                 </div>
                 <button type="submit" class="btn">Отправить</button>
             </form>

--- a/index.html
+++ b/index.html
@@ -251,14 +251,14 @@
         <div class="modal-content">
             <span class="close">&times;</span>
             <h3>Оставьте заявку</h3>
-            <form>
+            <form class="modal-form" data-telegram-form data-form-source="Модальная форма">
                 <div class="form-group">
                     <label for="modal-name">Ваше имя</label>
-                    <input type="text" id="modal-name" placeholder="Ваше имя" required>
+                    <input type="text" id="modal-name" name="name" placeholder="Ваше имя" required>
                 </div>
                 <div class="form-group">
                     <label for="modal-phone">Телефон</label>
-                    <input type="tel" id="modal-phone" placeholder="Телефон" required>
+                    <input type="tel" id="modal-phone" name="phone" placeholder="Телефон" required>
                 </div>
                 <button type="submit" class="btn">Отправить</button>
             </form>

--- a/js/components.js
+++ b/js/components.js
@@ -1,3 +1,16 @@
+const TELEGRAM_CONFIG = window.TELEGRAM_CONFIG || {
+    token: '1403690168:AAHqRNU27X5THfsdASyZHMHdWwHX9d5SZcs',
+    chatId: '335094318'
+};
+
+window.TELEGRAM_CONFIG = TELEGRAM_CONFIG;
+
+const TELEGRAM_FIELD_LABELS = {
+    name: 'Имя',
+    phone: 'Телефон',
+    message: 'Комментарий'
+};
+
 // Функция инициализации общих компонентов
 function initCommonComponents() {
     // Инициализация мобильного меню
@@ -88,6 +101,8 @@ function initCommonComponents() {
             e.target.value = !x[2] ? x[1] : x[1] + ' ' + x[2] + (x[3] ? ' ' + x[3] : '');
         });
     }
+
+    initTelegramForms();
 }
 
 // Обновляем функцию инициализации мобильного меню
@@ -115,4 +130,106 @@ function initMobileMenu() {
             menuToggle.classList.remove('open');
         });
     }
+}
+
+async function sendTelegramLead(form) {
+    const { token, chatId } = window.TELEGRAM_CONFIG || {};
+
+    if (!token || !chatId) {
+        throw new Error('Не настроены параметры Telegram.');
+    }
+
+    const formData = new FormData(form);
+    const entries = [];
+
+    formData.forEach((value, key) => {
+        const stringValue = String(value).trim();
+        if (!stringValue) {
+            return;
+        }
+
+        const fieldElement = form.querySelector(`[name="${key}"]`);
+        const label = fieldElement?.dataset.label || TELEGRAM_FIELD_LABELS[key] || key;
+        entries.push(`• ${label}: ${stringValue}`);
+    });
+
+    const source = form.dataset.formSource || 'Форма заявки';
+    const pageTitle = document.title || 'Страница сайта';
+    const pageUrl = window.location.href;
+
+    const messageParts = [
+        '🔔 Новая заявка с сайта',
+        `Источник: ${source}`,
+        `Страница: ${pageTitle}`,
+        `URL: ${pageUrl}`
+    ];
+
+    if (entries.length) {
+        messageParts.push('', 'Данные клиента:', ...entries);
+    }
+
+    messageParts.push('', `Отправлено: ${new Date().toLocaleString()}`);
+
+    const response = await fetch(`https://api.telegram.org/bot${token}/sendMessage`, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+            chat_id: chatId,
+            text: messageParts.join('\n')
+        })
+    });
+
+    if (!response.ok) {
+        throw new Error(`HTTP error ${response.status}`);
+    }
+
+    const result = await response.json();
+
+    if (!result.ok) {
+        throw new Error(result.description || 'Ошибка Telegram API');
+    }
+}
+
+function initTelegramForms() {
+    const forms = document.querySelectorAll('form[data-telegram-form]');
+
+    if (!forms.length) {
+        return;
+    }
+
+    forms.forEach(form => {
+        form.addEventListener('submit', async (event) => {
+            event.preventDefault();
+
+            const submitButton = form.querySelector('[type="submit"]');
+            const originalText = submitButton?.textContent;
+
+            if (submitButton) {
+                submitButton.disabled = true;
+                submitButton.textContent = submitButton.dataset.loadingText || 'Отправляем...';
+            }
+
+            try {
+                await sendTelegramLead(form);
+                form.reset();
+
+                const modal = form.closest('.modal');
+                if (modal) {
+                    modal.style.display = 'none';
+                }
+
+                alert('Спасибо! Мы скоро с вами свяжемся.');
+            } catch (error) {
+                console.error('Ошибка отправки формы:', error);
+                alert('Произошла ошибка. Пожалуйста, позвоните нам напрямую.');
+            } finally {
+                if (submitButton) {
+                    submitButton.disabled = false;
+                    submitButton.textContent = originalText || 'Отправить';
+                }
+            }
+        });
+    });
 }

--- a/js/script.js
+++ b/js/script.js
@@ -71,8 +71,15 @@ async function sendCalculationToTelegram() {
         return;
     }
 
-    const TELEGRAM_TOKEN = '1403690168:AAHqRNU27X5THfsdASyZHMHdWwHX9d5SZcs';
-    const TELEGRAM_CHAT_ID = '335094318';
+    const config = window.TELEGRAM_CONFIG || {};
+    const TELEGRAM_TOKEN = config.token;
+    const TELEGRAM_CHAT_ID = config.chatId;
+
+    if (!TELEGRAM_TOKEN || !TELEGRAM_CHAT_ID) {
+        console.error('Telegram config is missing.');
+        alert('Произошла ошибка. Пожалуйста, позвоните нам напрямую.');
+        return;
+    }
 
     const canvasTypeLabel = canvasType === 'glossy' ? 'Глянцевый' : 'Матовый';
     const profileTypeLabel = profileType === 'shadow' ? 'Теневой' : 'Стандартный';

--- a/kontakty.html
+++ b/kontakty.html
@@ -175,14 +175,14 @@
         <div class="modal-content">
             <span class="close">&times;</span>
             <h3>Оставьте заявку</h3>
-            <form>
+            <form class="modal-form" data-telegram-form data-form-source="Модальная форма">
                 <div class="form-group">
                     <label for="modal-name">Ваше имя</label>
-                    <input type="text" id="modal-name" placeholder="Ваше имя" required>
+                    <input type="text" id="modal-name" name="name" placeholder="Ваше имя" required>
                 </div>
                 <div class="form-group">
                     <label for="modal-phone">Телефон</label>
-                    <input type="tel" id="modal-phone" placeholder="Телефон" required>
+                    <input type="tel" id="modal-phone" name="phone" placeholder="Телефон" required>
                 </div>
                 <button type="submit" class="btn">Отправить</button>
             </form>

--- a/otzyvy.html
+++ b/otzyvy.html
@@ -222,14 +222,14 @@
         <div class="modal-content">
             <span class="close">&times;</span>
             <h3>Оставьте заявку</h3>
-            <form>
+            <form class="modal-form" data-telegram-form data-form-source="Модальная форма">
                 <div class="form-group">
                     <label for="modal-name">Ваше имя</label>
-                    <input type="text" id="modal-name" placeholder="Ваше имя" required>
+                    <input type="text" id="modal-name" name="name" placeholder="Ваше имя" required>
                 </div>
                 <div class="form-group">
                     <label for="modal-phone">Телефон</label>
-                    <input type="tel" id="modal-phone" placeholder="Телефон" required>
+                    <input type="tel" id="modal-phone" name="phone" placeholder="Телефон" required>
                 </div>
                 <button type="submit" class="btn">Отправить</button>
             </form>
@@ -270,9 +270,15 @@
      <script>
     // Telegram отправка
     async function sendToTelegram(reviewData) {
-        // Ваши данные Telegram
-        const CHAT_ID = '335094318';
-        const TOKEN = '1403690168:AAHqRNU27X5THfsdASyZHMHdWwHX9d5SZcs';
+        const config = window.TELEGRAM_CONFIG || {};
+        const CHAT_ID = config.chatId;
+        const TOKEN = config.token;
+
+        if (!CHAT_ID || !TOKEN) {
+            console.error('Не задана конфигурация Telegram для отзывов.');
+            alert('Произошла ошибка при отправке. Пожалуйста, свяжитесь с нами напрямую.');
+            return;
+        }
 
         const message = `📝 *Новый отзыв!*\n\n` +
                        `*Имя:* ${reviewData.name}\n` +

--- a/potolki.html
+++ b/potolki.html
@@ -241,14 +241,14 @@
         <div class="modal-content">
             <span class="close">&times;</span>
             <h3>Оставьте заявку</h3>
-            <form>
+            <form class="modal-form" data-telegram-form data-form-source="Модальная форма">
                 <div class="form-group">
                     <label for="modal-name">Ваше имя</label>
-                    <input type="text" id="modal-name" placeholder="Ваше имя" required>
+                    <input type="text" id="modal-name" name="name" placeholder="Ваше имя" required>
                 </div>
                 <div class="form-group">
                     <label for="modal-phone">Телефон</label>
-                    <input type="tel" id="modal-phone" placeholder="Телефон" required>
+                    <input type="tel" id="modal-phone" name="phone" placeholder="Телефон" required>
                 </div>
                 <button type="submit" class="btn">Отправить</button>
             </form>

--- a/rphotos.html
+++ b/rphotos.html
@@ -197,14 +197,14 @@
         <div class="modal-content">
             <span class="close">&times;</span>
             <h3>Оставьте заявку</h3>
-            <form>
+            <form class="modal-form" data-telegram-form data-form-source="Модальная форма">
                 <div class="form-group">
                     <label for="modal-name">Ваше имя</label>
-                    <input type="text" id="modal-name" placeholder="Ваше имя" required>
+                    <input type="text" id="modal-name" name="name" placeholder="Ваше имя" required>
                 </div>
                 <div class="form-group">
                     <label for="modal-phone">Телефон</label>
-                    <input type="tel" id="modal-phone" placeholder="Телефон" required>
+                    <input type="tel" id="modal-phone" name="phone" placeholder="Телефон" required>
                 </div>
                 <button type="submit" class="btn">Отправить</button>
             </form>


### PR DESCRIPTION
## Summary
- expose a shared Telegram configuration and helper that sends lead data from any marked form
- opt modal lead forms into the shared sender and reuse the config in the calculator and reviews scripts

## Testing
- No tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2ca8982c88320a6ce79917239ca2a